### PR TITLE
Unused validator

### DIFF
--- a/unused.js
+++ b/unused.js
@@ -1,0 +1,9 @@
+Checkit.Validators.unused = function (val, table, column, knex) {
+  return knex(table)
+  .where(column, val.toLowerCase())
+  .then(function (result) {
+    if (result.length > 0) {
+      throw new Error('That ' + column + ' is already in use.');
+    }
+  });
+};


### PR DESCRIPTION
As per checkit docs. Modified by tkellen, and again modified by me.

Instead of having to have knex in scope, I thought it would be nice to pass it in as a param. Because of this, the rule cannot be called using

``` javascript
email: ['unused:tablename:columnname']
```

but must be used like this:

``` javascript
email: {
  rule:'unused',
  params:['users', 'email', knex]
}
```

Thoughts on the injection of knex? By doing this we don't need to have knex in scope, which might be nice if you add your validator using a file, where you don't use bookshelf or knex directly.

It is a little bit less comfortable, but personally I'm willing to make that tradeoff.
